### PR TITLE
Task like `npm run lint:fix` get turned into `npm_run_lint-fix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Webtools releases
 
 ## [Unreleased]
+### Added
+- Task like `npm run lint:fix` get turned into `npm_run_lint-fix` (so the colons don't screw up Gradle)
 
 ## [1.1.0] - 2024-08-04
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ node {
     inputs.dir('somedir').withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.dir('build/some-output')
   }
+  // if an npm script contains `:` it willbe transformed into `-`
+  npm_run 'lint:fix', {} // becomes `npm_run_lint-fix`
 }
 ```
 

--- a/src/main/java/com/diffplug/webtools/node/NodePlugin.java
+++ b/src/main/java/com/diffplug/webtools/node/NodePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 DiffPlug
+ * Copyright (C) 2024-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,8 +53,8 @@ public class NodePlugin implements Plugin<Project> {
 		}
 
 		public TaskProvider<?> npm_run(String name, Action<NpmRunTask> taskConfig) {
-			return project.getTasks().register("npm_run_" + name, NpmRunTask.class, task -> {
-				task.taskName = name;
+			return project.getTasks().register("npm_run_" + name.replace(':', '-'), NpmRunTask.class, task -> {
+				task.npmTaskName = name;
 				try {
 					setup.nodeVersion = nvmRc(findNvmRc(project.getProjectDir()));
 					setup.npmVersion = "provided";
@@ -75,12 +75,12 @@ public class NodePlugin implements Plugin<Project> {
 
 	@CacheableTask
 	public abstract static class NpmRunTask extends DefaultTask {
-		public String taskName;
+		public String npmTaskName;
 		private TreeMap<String, String> environment = new TreeMap<>();
 
 		@Input
-		public String getTaskName() {
-			return taskName;
+		public String getNpmTaskName() {
+			return npmTaskName;
 		}
 
 		@Input
@@ -101,7 +101,7 @@ public class NodePlugin implements Plugin<Project> {
 			setup.start(getProjectDir().get().getAsFile());
 			// run the gulp task
 			ProxyConfig proxyConfig = new ProxyConfig(Collections.emptyList());
-			setup.factory().getNpmRunner(proxyConfig, null).execute("run " + taskName, environment);
+			setup.factory().getNpmRunner(proxyConfig, null).execute("run " + npmTaskName, environment);
 		}
 	}
 


### PR DESCRIPTION
…he colons don't screw up Gradle)